### PR TITLE
Add info to index page & update ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@
 
 Templates for sending emails, based on [Foundation for Emails](https://foundation.zurb.com/emails.html).
 
-This repository provides a local preview, so you can see what the final messages will look like.
-
-✨ [**Live Preview**](https://wireapp.github.io/wire-emails/dist/) ✨
+Visit [wireapp.github.io/wire-emails/dist](https://wireapp.github.io/wire-emails/dist/) for the latest ✨ [**Live Preview**](https://wireapp.github.io/wire-emails/dist/) ✨
 
 ## For Designers
 
@@ -16,8 +14,6 @@ This repository provides a local preview, so you can see what the final messages
 If the files are not updated automatically with the `Auto build` commit message, check the [commit list](https://github.com/wireapp/wire-emails/commits/master) for possible errors.
 
 To update shared text modules like headers, footers or signatures, edit the corresponding files in the [`src/partials`](https://github.com/wireapp/wire-emails/tree/master/src/partials) folder.
-
-**Coming soon:** Instant preview of the templates inside the browser!
 
 ## For Engineers
 
@@ -30,9 +26,11 @@ yarn
 
 ### Start the local preview
 
-Run `yarn start` and check the results at [`localhost:3000`](http://localhost:3000).
+This repository provides a local preview, so you can see what the final messages will look like.
 
-A table of contents appears with links to each message. Click a link to display the message preview in a new tab.
+To start the preview, run `yarn start` and check the results at [`localhost:3000`](http://localhost:3000).
+
+A table of contents appears with links to each message. Click a link to display the rendered message content.
 
 ### Update
 

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -6,6 +6,9 @@ subject: Wire · Email Templates
 <container class="index">
   <row>
     <columns small="12">
+      <spacer size="24"></spacer>
+      <h1>Wire Email Templates Preview</h1>
+      <p>Click the links below to display the content of each message:</p>
       <h5>Provider</h5>
       <ol>
         <li><a href="en/provider/activation.html">Activation</a></li>
@@ -29,4 +32,6 @@ subject: Wire · Email Templates
       </ol>
     </columns>
   </row>
+  <p>For source and instructions, see
+    <a href="https://github.com/wireapp/wire-emails">github.com/wireapp/wire-emails</a>.</p>
 </container>


### PR DESCRIPTION
@lipis: Looks like the links on the index page no longer open new tabs.

Not sure if that’s intentional, but I changed the descriptions accordingly.