### PR TITLE
Fix partial reference in team activation message

### DIFF
--- a/src/pages/de/user/email/team-activation.html
+++ b/src/pages/de/user/email/team-activation.html
@@ -11,7 +11,7 @@ subject: "Wire Benutzerkonto"
       <center><button class="radius" href="${url}">Überprüfe</button></center>
       <spacer size="24"></spacer>
       {{> de/link-button}}
-      {{> de/ignore}}
+      {{> de/questions}}
     </columns>
   </row>
 </container>

--- a/src/pages/en/user/email/team-activation.html
+++ b/src/pages/en/user/email/team-activation.html
@@ -11,7 +11,7 @@ subject: "Wire Account"
       <center><button class="radius" href="${url}">Verify</button></center>
       <spacer size="24"></spacer>
       {{> en/link-button}}
-      {{> en/ignore}}
+      {{> en/questions}}
     </columns>
   </row>
 </container>

--- a/src/pages/et/user/email/team-activation.html
+++ b/src/pages/et/user/email/team-activation.html
@@ -11,7 +11,7 @@ subject: "Sinu Wire konto"
       <center><button class="radius" href="${url}">Kinnita</button></center>
       <spacer size="24"></spacer>
       {{> et/link-button}}
-      {{> et/ignore}}
+      {{> et/questions}}
     </columns>
   </row>
 </container>

--- a/src/pages/lt/user/email/team-activation.html
+++ b/src/pages/lt/user/email/team-activation.html
@@ -11,7 +11,7 @@ subject: "Wire paskyra"
       <center><button class="radius" href="${url}">Patvirtinti</button></center>
       <spacer size="24"></spacer>
       {{> lt/link-button}}
-      {{> lt/ignore}}
+      {{> lt/questions}}
     </columns>
   </row>
 </container>

--- a/src/pages/ru/user/email/team-activation.html
+++ b/src/pages/ru/user/email/team-activation.html
@@ -11,7 +11,7 @@ subject: "Учётная запись Wire"
       <center><button class="radius" href="${url}">Подтвердить</button></center>
       <spacer size="24"></spacer>
       {{> ru/link-button}}
-      {{> ru/ignore}}
+      {{> ru/questions}}
     </columns>
   </row>
 </container>


### PR DESCRIPTION
The wrong partial is being called here, which erroneously adds the provider account reference instead of the “any questions” copy used for the standard (personal) user activation message.

Fixes #49.