### PR TITLE
[WPB-18127] Email templates for app notifications.

### DIFF
--- a/src/pages/en/team/email/app-availability-change.html
+++ b/src/pages/en/team/email/app-availability-change.html
@@ -13,9 +13,9 @@ subject: "An app's availability was changed in your team"
          <strong>New availability:</strong> ${new_availability}</p>
       <p><strong>Team name:</strong> ${team_name}<br>
          <strong>Team ID:</strong> ${team_id}</p>
-      <spacer size="16"></spacer>
-      <center><button href="${url}" class="radius">Open Team Management</button></center>
-      <spacer size="8"></spacer>
+      <div style="height: 16px;"></div>
+      <div style="text-align: center;"><button href="${url}" class="radius">Open Team Management</button></div>
+      <div style="height: 8px;"></div>
       {{> en/questions}}
     </columns>
   </row>

--- a/src/pages/en/team/email/app-availability-change.html
+++ b/src/pages/en/team/email/app-availability-change.html
@@ -1,0 +1,23 @@
+---
+subject: "An app's availability was changed in your team"
+---
+
+<container>
+  <row>
+    <columns small="12">
+      <h4>Availability change for an app</h4>
+      <p>${actor} has changed the availability of an app from your team.</p>
+      <p><strong>App name:</strong> ${app_name}<br>
+         <strong>Date:</strong> ${date}</p>
+      <p><strong>Previous availability:</strong> ${previous_availability}<br>
+         <strong>New availability:</strong> ${new_availability}</p>
+      <p><strong>Team name:</strong> ${team_name}<br>
+         <strong>Team ID:</strong> ${team_id}</p>
+      <spacer size="16"></spacer>
+      <center><button href="${url}" class="radius">Open Team Management</button></center>
+      <spacer size="8"></spacer>
+      {{> en/questions}}
+    </columns>
+  </row>
+</container>
+{{> en/footer}}

--- a/src/pages/en/team/email/app-creation.html
+++ b/src/pages/en/team/email/app-creation.html
@@ -1,0 +1,23 @@
+---
+subject: 'A new app was created in your team'
+---
+
+<container>
+  <row>
+    <columns small="12">
+      <h4>New app created</h4>
+      <p>${actor} has created an app in your team.</p>
+      <p><strong>App name:</strong> ${app_name}<br>
+         <strong>Date:</strong> ${date}</p>
+      <p><strong>Team name:</strong> ${team_name}<br>
+         <strong>Team ID:</strong> ${team_id}</p>
+      <p><strong>Permissions:</strong><br>
+         <ul>${permissions}</ul></p>
+      <spacer size="16"></spacer>
+      <center><button href="${url}" class="radius">Open Team Management</button></center>
+      <spacer size="8"></spacer>
+      {{> en/questions}}
+    </columns>
+  </row>
+</container>
+{{> en/footer}}

--- a/src/pages/en/team/email/app-creation.html
+++ b/src/pages/en/team/email/app-creation.html
@@ -13,9 +13,9 @@ subject: 'A new app was created in your team'
          <strong>Team ID:</strong> ${team_id}</p>
       <p><strong>Permissions:</strong><br>
          <ul>${permissions}</ul></p>
-      <spacer size="16"></spacer>
-      <center><button href="${url}" class="radius">Open Team Management</button></center>
-      <spacer size="8"></spacer>
+      <div style="height: 16px;"></div>
+      <div style="text-align: center;"><button href="${url}" class="radius">Open Team Management</button></div>
+      <div style="height: 8px;"></div>
       {{> en/questions}}
     </columns>
   </row>

--- a/src/pages/en/team/email/app-deletion.html
+++ b/src/pages/en/team/email/app-deletion.html
@@ -1,0 +1,21 @@
+---
+subject: 'An app was deleted from your team'
+---
+
+<container>
+  <row>
+    <columns small="12">
+      <h4>App deleted</h4>
+      <p>${actor} has deleted an app in your team.</p>
+      <p><strong>App name:</strong> ${app_name}<br>
+         <strong>Date:</strong> ${date}</p>
+      <p><strong>Team name:</strong> ${team_name}<br>
+         <strong>Team ID:</strong> ${team_id}</p>
+      <spacer size="16"></spacer>
+      <center><button href="${url}" class="radius">Open Team Management</button></center>
+      <spacer size="8"></spacer>
+      {{> en/questions}}
+    </columns>
+  </row>
+</container>
+{{> en/footer}}

--- a/src/pages/en/team/email/app-deletion.html
+++ b/src/pages/en/team/email/app-deletion.html
@@ -11,9 +11,9 @@ subject: 'An app was deleted from your team'
          <strong>Date:</strong> ${date}</p>
       <p><strong>Team name:</strong> ${team_name}<br>
          <strong>Team ID:</strong> ${team_id}</p>
-      <spacer size="16"></spacer>
-      <center><button href="${url}" class="radius">Open Team Management</button></center>
-      <spacer size="8"></spacer>
+      <div style="height: 16px;"></div>
+      <div style="text-align: center;"><button href="${url}" class="radius">Open Team Management</button></div>
+      <div style="height: 8px;"></div>
       {{> en/questions}}
     </columns>
   </row>

--- a/src/pages/en/team/email/app-metadata-change.html
+++ b/src/pages/en/team/email/app-metadata-change.html
@@ -1,0 +1,22 @@
+---
+subject: 'App details were changed in your team'
+---
+
+<container>
+  <row>
+    <columns small="12">
+      <h4>Details changed for an app</h4>
+      <p>${actor} has changed the details of an app from your team.</p>
+      <p><strong>New name:</strong> ${new_app_name}<br>
+         <strong>Previous name:</strong> ${previous_app_name}<br>
+         <strong>Date:</strong> ${date}</p>
+      <p><strong>Team name:</strong> ${team_name}<br>
+         <strong>Team ID:</strong> ${team_id}</p>
+      <spacer size="16"></spacer>
+      <center><button href="${url}" class="radius">Open Team Management</button></center>
+      <spacer size="8"></spacer>
+      {{> en/questions}}
+    </columns>
+  </row>
+</container>
+{{> en/footer}}

--- a/src/pages/en/team/email/app-metadata-change.html
+++ b/src/pages/en/team/email/app-metadata-change.html
@@ -12,9 +12,9 @@ subject: 'App details were changed in your team'
          <strong>Date:</strong> ${date}</p>
       <p><strong>Team name:</strong> ${team_name}<br>
          <strong>Team ID:</strong> ${team_id}</p>
-      <spacer size="16"></spacer>
-      <center><button href="${url}" class="radius">Open Team Management</button></center>
-      <spacer size="8"></spacer>
+      <div style="height: 16px;"></div>
+      <div style="text-align: center;"><button href="${url}" class="radius">Open Team Management</button></div>
+      <div style="height: 8px;"></div>
       {{> en/questions}}
     </columns>
   </row>

--- a/src/pages/en/team/email/app-token-change.html
+++ b/src/pages/en/team/email/app-token-change.html
@@ -11,9 +11,9 @@ subject: "An app's token was updated in your team"
          <strong>Date:</strong> ${date}</p>
       <p><strong>Team name:</strong> ${team_name}<br>
          <strong>Team ID:</strong> ${team_id}</p>
-      <spacer size="16"></spacer>
-      <center><button href="${url}" class="radius">Open Team Management</button></center>
-      <spacer size="8"></spacer>
+      <div style="height: 16px;"></div>
+      <div style="text-align: center;"><button href="${url}" class="radius">Open Team Management</button></div>
+      <div style="height: 8px;"></div>
       {{> en/questions}}
     </columns>
   </row>

--- a/src/pages/en/team/email/app-token-change.html
+++ b/src/pages/en/team/email/app-token-change.html
@@ -1,0 +1,21 @@
+---
+subject: "An app's token was updated in your team"
+---
+
+<container>
+  <row>
+    <columns small="12">
+      <h4>Updated app authentication token</h4>
+      <p>${actor} has updated the authentication token of an app from your team.</p>
+      <p><strong>App name:</strong> ${app_name}<br>
+         <strong>Date:</strong> ${date}</p>
+      <p><strong>Team name:</strong> ${team_name}<br>
+         <strong>Team ID:</strong> ${team_id}</p>
+      <spacer size="16"></spacer>
+      <center><button href="${url}" class="radius">Open Team Management</button></center>
+      <spacer size="8"></spacer>
+      {{> en/questions}}
+    </columns>
+  </row>
+</container>
+{{> en/footer}}

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -117,6 +117,26 @@ subject: Wire · Email Templates Preview
           <a href="en/team/email/idp-config-change.html">Identity Provider configuration change</a>
         </li>
         <li>
+          <a href="en/team/email/app-creation.html"><span class="flag-icon flag-icon-squared flag-icon-us"></span></a>
+          <a href="en/team/email/app-creation.html">App creation</a>
+        </li>
+        <li>
+          <a href="en/team/email/app-deletion.html"><span class="flag-icon flag-icon-squared flag-icon-us"></span></a>
+          <a href="en/team/email/app-deletion.html">App deletion</a>
+        </li>
+        <li>
+          <a href="en/team/email/app-availability-change.html"><span class="flag-icon flag-icon-squared flag-icon-us"></span></a>
+          <a href="en/team/email/app-availability-change.html">App availability change</a>
+        </li>
+        <li>
+          <a href="en/team/email/app-metadata-change.html"><span class="flag-icon flag-icon-squared flag-icon-us"></span></a>
+          <a href="en/team/email/app-metadata-change.html">App metadata change</a>
+        </li>
+        <li>
+          <a href="en/team/email/app-token-change.html"><span class="flag-icon flag-icon-squared flag-icon-us"></span></a>
+          <a href="en/team/email/app-token-change.html">App token change</a>
+        </li>
+        <li>
           <a href="en/team/email/migration.html"><span class="flag-icon flag-icon-squared flag-icon-us"></span></a>
           <a href="de/team/email/migration.html"><span class="flag-icon flag-icon-squared flag-icon-de"></span></a>
           <a href="et/team/email/migration.html"><span class="flag-icon flag-icon-squared flag-icon-ee"></span></a>


### PR DESCRIPTION
Prior art: https://github.com/wireapp/wire-emails/pull/461/changes

The designs:

<img width="1920" height="1168" alt="Screenshot From 2026-07-14 13-31-15" src="https://github.com/user-attachments/assets/45964a46-128b-4288-836f-408b99a765a4" />

The actual templates:

<img width="1136" height="768" alt="Screenshot From 2026-07-14 14-15-55" src="https://github.com/user-attachments/assets/ed5dff81-4768-43bb-bbdb-52c3dcf1ef6a" /><br>
<img width="1136" height="768" alt="Screenshot From 2026-07-14 14-17-45" src="https://github.com/user-attachments/assets/856c3a49-9568-48ef-98d2-abc315506652" /><br>
<img width="1083" height="660" alt="Screenshot From 2026-07-15 12-58-02" src="https://github.com/user-attachments/assets/c68d5fc4-3083-4773-94e3-5c957dce0f8d" />
<br>
<img width="1136" height="768" alt="Screenshot From 2026-07-14 14-20-00" src="https://github.com/user-attachments/assets/789ee9dc-d899-47dd-8dac-20035b4bda6e" /><br>
<img width="1136" height="768" alt="Screenshot From 2026-07-14 14-20-52" src="https://github.com/user-attachments/assets/c5c3c865-3aba-48bb-982d-b4c989d4bc49" /><br>
