### PR TITLE
[WPB-18127] Template variables need to be vanilla strings.

### DIFF
--- a/src/pages/de/team/email/app-creation.html
+++ b/src/pages/de/team/email/app-creation.html
@@ -12,7 +12,7 @@ Betreff: 'Eine neue App wurde in Ihrem Team erstellt'
       <p><strong>Team-Name:</strong> ${team_name}<br>
          <strong>Team-ID:</strong> ${team_id}</p>
       <p><strong>Berechtigungen:</strong><br>
-         <ul>${permissions}</ul></p>
+         ${permissions}</p>
       <div style="height: 16px;"></div>
       <div style="text-align: center;"><button href="${url}" class="radius">Team-Management öffnen</button></div>
       <div style="height: 8px;"></div>

--- a/src/pages/en/team/email/app-creation.html
+++ b/src/pages/en/team/email/app-creation.html
@@ -12,7 +12,7 @@ subject: 'A new app was created in your team'
       <p><strong>Team name:</strong> ${team_name}<br>
          <strong>Team ID:</strong> ${team_id}</p>
       <p><strong>Permissions:</strong><br>
-         <ul>${permissions}</ul></p>
+         ${permissions}</p>
       <div style="height: 16px;"></div>
       <div style="text-align: center;"><button href="${url}" class="radius">Open Team Management</button></div>
       <div style="height: 8px;"></div>

--- a/src/pages/et/team/email/app-creation.html
+++ b/src/pages/et/team/email/app-creation.html
@@ -12,7 +12,7 @@ subject: 'A new app was created in your team'
       <p><strong>Team name:</strong> ${team_name}<br>
          <strong>Team ID:</strong> ${team_id}</p>
       <p><strong>Permissions:</strong><br>
-         <ul>${permissions}</ul></p>
+         ${permissions}</p>
       <div style="height: 16px;"></div>
       <div style="text-align: center;"><button href="${url}" class="radius">Open Team Management</button></div>
       <div style="height: 8px;"></div>

--- a/src/pages/fr/team/email/app-creation.html
+++ b/src/pages/fr/team/email/app-creation.html
@@ -12,7 +12,7 @@ subject: 'A new app was created in your team'
       <p><strong>Team name:</strong> ${team_name}<br>
          <strong>Team ID:</strong> ${team_id}</p>
       <p><strong>Permissions:</strong><br>
-         <ul>${permissions}</ul></p>
+         ${permissions}</p>
       <div style="height: 16px;"></div>
       <div style="text-align: center;"><button href="${url}" class="radius">Open Team Management</button></div>
       <div style="height: 8px;"></div>

--- a/src/pages/it/team/email/app-creation.html
+++ b/src/pages/it/team/email/app-creation.html
@@ -12,7 +12,7 @@ subject: 'A new app was created in your team'
       <p><strong>Team name:</strong> ${team_name}<br>
          <strong>Team ID:</strong> ${team_id}</p>
       <p><strong>Permissions:</strong><br>
-         <ul>${permissions}</ul></p>
+         ${permissions}</p>
       <div style="height: 16px;"></div>
       <div style="text-align: center;"><button href="${url}" class="radius">Open Team Management</button></div>
       <div style="height: 8px;"></div>

--- a/src/pages/ja/team/email/app-creation.html
+++ b/src/pages/ja/team/email/app-creation.html
@@ -12,7 +12,7 @@ subject: 'A new app was created in your team'
       <p><strong>Team name:</strong> ${team_name}<br>
          <strong>Team ID:</strong> ${team_id}</p>
       <p><strong>Permissions:</strong><br>
-         <ul>${permissions}</ul></p>
+         ${permissions}</p>
       <div style="height: 16px;"></div>
       <div style="text-align: center;"><button href="${url}" class="radius">Open Team Management</button></div>
       <div style="height: 8px;"></div>

--- a/src/pages/lt/team/email/app-creation.html
+++ b/src/pages/lt/team/email/app-creation.html
@@ -12,7 +12,7 @@ subject: 'A new app was created in your team'
       <p><strong>Team name:</strong> ${team_name}<br>
          <strong>Team ID:</strong> ${team_id}</p>
       <p><strong>Permissions:</strong><br>
-         <ul>${permissions}</ul></p>
+         ${permissions}</p>
       <div style="height: 16px;"></div>
       <div style="text-align: center;"><button href="${url}" class="radius">Open Team Management</button></div>
       <div style="height: 8px;"></div>

--- a/src/pages/pl/team/email/app-creation.html
+++ b/src/pages/pl/team/email/app-creation.html
@@ -12,7 +12,7 @@ subject: 'A new app was created in your team'
       <p><strong>Team name:</strong> ${team_name}<br>
          <strong>Team ID:</strong> ${team_id}</p>
       <p><strong>Permissions:</strong><br>
-         <ul>${permissions}</ul></p>
+         ${permissions}</p>
       <div style="height: 16px;"></div>
       <div style="text-align: center;"><button href="${url}" class="radius">Open Team Management</button></div>
       <div style="height: 8px;"></div>

--- a/src/pages/pt/team/email/app-creation.html
+++ b/src/pages/pt/team/email/app-creation.html
@@ -12,7 +12,7 @@ subject: 'A new app was created in your team'
       <p><strong>Team name:</strong> ${team_name}<br>
          <strong>Team ID:</strong> ${team_id}</p>
       <p><strong>Permissions:</strong><br>
-         <ul>${permissions}</ul></p>
+         ${permissions}</p>
       <div style="height: 16px;"></div>
       <div style="text-align: center;"><button href="${url}" class="radius">Open Team Management</button></div>
       <div style="height: 8px;"></div>

--- a/src/pages/ru/team/email/app-creation.html
+++ b/src/pages/ru/team/email/app-creation.html
@@ -12,7 +12,7 @@
       <p><strong>Team name:</strong> ${team_name}<br>
          <strong>Team ID:</strong> ${team_id}</p>
       <p><strong>Права доступа:</strong><br>
-         <ul>${permissions}</ul></p>
+         ${permissions}</p>
       <div style="height: 16px;"></div>
       <div style="text-align: center;"><button href="${url}" class="radius">Открыть управление командой</button></div>
       <div style="height: 8px;"></div>

--- a/src/pages/si/team/email/app-creation.html
+++ b/src/pages/si/team/email/app-creation.html
@@ -12,7 +12,7 @@ subject: 'A new app was created in your team'
       <p><strong>Team name:</strong> ${team_name}<br>
          <strong>Team ID:</strong> ${team_id}</p>
       <p><strong>Permissions:</strong><br>
-         <ul>${permissions}</ul></p>
+         ${permissions}</p>
       <div style="height: 16px;"></div>
       <div style="text-align: center;"><button href="${url}" class="radius">Open Team Management</button></div>
       <div style="height: 8px;"></div>

--- a/src/pages/tr/team/email/app-creation.html
+++ b/src/pages/tr/team/email/app-creation.html
@@ -12,7 +12,7 @@ subject: 'A new app was created in your team'
       <p><strong>Team name:</strong> ${team_name}<br>
          <strong>Team ID:</strong> ${team_id}</p>
       <p><strong>Permissions:</strong><br>
-         <ul>${permissions}</ul></p>
+         ${permissions}</p>
       <div style="height: 16px;"></div>
       <div style="text-align: center;"><button href="${url}" class="radius">Open Team Management</button></div>
       <div style="height: 8px;"></div>

--- a/src/pages/vi/team/email/app-creation.html
+++ b/src/pages/vi/team/email/app-creation.html
@@ -12,7 +12,7 @@ subject: 'A new app was created in your team'
       <p><strong>Team name:</strong> ${team_name}<br>
          <strong>Team ID:</strong> ${team_id}</p>
       <p><strong>Permissions:</strong><br>
-         <ul>${permissions}</ul></p>
+         ${permissions}</p>
       <div style="height: 16px;"></div>
       <div style="text-align: center;"><button href="${url}" class="radius">Open Team Management</button></div>
       <div style="height: 8px;"></div>


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/WPB-18127

```
With <ul>${permissios}</ul>, html-to-text was removing ${permissions} because
it's not wrapped in <li>.  Anyway, cross-format rendering of list is not
supported in wire-server, so this would never have worked.

Instead, we need to make do with rendering lists as "a, b, c, ...".
```

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability


----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
